### PR TITLE
Don't let the script delete CyanogenSetupWizard (fix #29)

### DIFF
--- a/20-freecyngn.sh
+++ b/20-freecyngn.sh
@@ -17,7 +17,6 @@ Browser
 CMAccount
 CMS
 CMSetupWizard
-CyanogenSetupWizard
 LockClock
 TimeService
 Voice+


### PR DESCRIPTION
According to #29, then the script can cause the quick settings and home button to not function (at least on a Nexus 5X and OnePlus 3 on CM13). Removing CyanogenSetupWizard from the script fixes this - but I can't say why.